### PR TITLE
feat(dashboard): auto-refresh, replay modal, price-trend chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An AI-powered sandbox where autonomous agents negotiate cloud compute (GPUs, CPUs) and settle transactions using real-world payment rails (Stripe, PayPal, crypto). The project demonstrates agent-to-agent markets, AI-driven negotiation, secure payments, and audit-grade logging—ideal proof-of-work for infra / AI / fintech recruiters.
 
+![dashboard](docs/dashboard.png)
+
 ---
 
 ## ⚙️ Key Features
@@ -182,3 +184,12 @@ If you encounter issues with enum types in PostgreSQL:
 1. Check current enum values: `\dT+ enum_name`
 2. Verify table structure: `\d table_name`
 3. Make sure all migrations have been applied: `alembic current`
+
+## Dashboard Features
+
+The Streamlit dashboard provides real-time monitoring of agent negotiations:
+
+- **Auto-refresh**: Toggle 5-second auto-refresh in the sidebar
+- **Quote History**: Adjust the number of visible quotes using the rows slider
+- **Negotiation Replay**: Click any quote row and use "Replay negotiation" to watch the turn-by-turn negotiation process
+- **Price Trends**: View historical price trends for all quotes

--- a/dashboard/plot.py
+++ b/dashboard/plot.py
@@ -1,0 +1,24 @@
+import streamlit as st
+import matplotlib.pyplot as plt
+
+
+def price_trend(df):
+    """Plot price trend over time for quotes."""
+    if df.empty:
+        return
+
+    # Convert price strings to float
+    df = df.copy()
+    df["price"] = df["price"].str.replace("$", "").astype(float)
+
+    fig, ax = plt.subplots()
+    ax.plot(df["created_at"], df["price"], marker="o")
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Price (USD)")
+    ax.set_title("Quote Price Trend – Last N")
+
+    # Rotate x-axis labels for better readability
+    plt.xticks(rotation=45)
+    plt.tight_layout()
+
+    st.pyplot(fig, clear_figure=True)

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -3,10 +3,19 @@ import requests
 import json
 import pandas as pd
 import streamlit as st
+import time
+from dashboard.plot import price_trend
 
 API_BASE = os.getenv("API_BASE", "http://localhost:8000")
 
 st.set_page_config("AgentCloud Dashboard", layout="wide")
+
+# Sidebar controls
+with st.sidebar:
+    st.title("Dashboard Controls")
+    refresh = st.toggle("Auto-refresh (5s)", value=False)
+    n_quotes = st.slider("Rows", 10, 50, 20)
+
 st.title("🤖 AgentCloud - Live Quote Feed")
 
 
@@ -49,56 +58,100 @@ def fetch_quotes(n: int = 20):
         return pd.DataFrame()
 
 
-# Fetch initial data
-df = fetch_quotes()
+# Auto-refresh loop
+while True:
+    # Fetch data
+    df = fetch_quotes(n_quotes)
 
-# Display interactive dataframe
-if not df.empty:
-    selected = st.dataframe(
-        df,
-        use_container_width=True,
-        height=400,
-        column_config={
-            "id": "Quote ID",
-            "resource_type": "Resource",
-            "duration_hours": "Duration (hrs)",
-            "price": "Price",
-            "buyer_max_price": "Max Price",
-            "status": "Status",
-            "created_at": "Created At",
-            "buyer_id": "Buyer ID",
-            "negotiation_log": None,  # Hide this column
-            "transactions": None,  # Hide this column
-        },
-    )
-
-    # Handle row selection
-    sel_rows = st.session_state.get("dataframe-row-selected-indices", [])
-    if sel_rows:
-        q = df.iloc[sel_rows[0]].to_dict()
-        st.subheader(f"Quote {q['id']} details")
-        st.write(
-            f"**Status:** {q['status']} • **Price:** {q['price']} • **Max Price:** {q['buyer_max_price']}"
+    # Display interactive dataframe
+    if not df.empty:
+        selected_quotes = st.dataframe(
+            df,
+            use_container_width=True,
+            height=400,
+            column_config={
+                "id": "Quote ID",
+                "resource_type": "Resource",
+                "duration_hours": "Duration (hrs)",
+                "price": "Price",
+                "buyer_max_price": "Max Price",
+                "status": "Status",
+                "created_at": "Created At",
+                "buyer_id": "Buyer ID",
+                "negotiation_log": None,  # Hide this column
+                "transactions": None,  # Hide this column
+            },
+            hide_index=True,  # Hide the index column
+            on_select="rerun",
+            selection_mode="single-row",
+            key="quote_table",
         )
 
-        # Display negotiation log as expandable JSON
-        if q["negotiation_log"]:
-            st.subheader("Negotiation Log")
-            st.json(
-                (
-                    json.loads(q["negotiation_log"])
-                    if isinstance(q["negotiation_log"], str)
-                    else q["negotiation_log"]
-                ),
-                expanded=False,
-            )
-
-        # Display transactions if any
-        if q["transactions"]:
-            st.subheader("Transactions")
-            for tx in q["transactions"]:
+        # Handle row selection
+        if selected_quotes.selection["rows"]:
+            # Get the selected quote
+            quote_id = df.iloc[selected_quotes.selection["rows"][0]]["id"]
+            quote_row = df[df["id"] == quote_id]
+            if not quote_row.empty:
+                q = quote_row.iloc[0].to_dict()
+                st.subheader(f"Quote {q['id']} details")
                 st.write(
-                    f"- {tx['provider'].upper()}: {tx['status']} (${tx['amount_usd']:.2f})"
+                    f"**Status:** {q['status']} • **Price:** {q['price']} • **Max Price:** {q['buyer_max_price']}"
                 )
-else:
-    st.info("No quotes found. Create some quotes to see them here.")
+
+                # Add Replay button
+                if st.button("Replay negotiation"):
+
+                    @st.dialog(f"Negotiation log - Quote {q['id']}")
+                    def show_negotiation():
+                        log = (
+                            json.loads(q["negotiation_log"])
+                            if isinstance(q["negotiation_log"], str)
+                            else q["negotiation_log"]
+                        )
+                        total_turns = len(log)
+
+                        for i, turn in enumerate(log):
+                            st.markdown(
+                                f"**Turn {i+1}**: {turn['role']} → ${turn['price']}"
+                            )
+                            st.progress((i + 1) / total_turns)
+                            time.sleep(0.5)  # Add delay for animation effect
+
+                    show_negotiation()  # Call the decorated function
+
+                # Display negotiation log as expandable JSON
+                if q["negotiation_log"]:
+                    st.subheader("Negotiation Log")
+                    st.json(
+                        (
+                            json.loads(q["negotiation_log"])
+                            if isinstance(q["negotiation_log"], str)
+                            else q["negotiation_log"]
+                        ),
+                        expanded=False,
+                    )
+
+                # Display transactions if any
+                if q["transactions"]:
+                    st.subheader("Transactions")
+                    for tx in q["transactions"]:
+                        st.write(
+                            f"- {tx['provider'].upper()}: {tx['status']} (${tx['amount_usd']:.2f})"
+                        )
+            else:
+                st.error(f"Quote ID {quote_id} not found")
+
+    else:
+        st.info("No quotes found. Create some quotes to see them here.")
+
+    # Add price trend visualization
+    st.divider()
+    st.subheader("Price Trend")
+    price_trend(df[::-1])  # Reverse order for oldest → newest
+
+    # Handle auto-refresh
+    if not refresh:
+        break
+    time.sleep(5)
+    st.experimental_rerun()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi
 httpx
 langchain-openai
 langchain-core
+matplotlib
 openai
 pandas>=2.2
 paypalrestsdk
@@ -12,7 +13,7 @@ python-dotenv
 python-multipart
 sqlalchemy
 sqlmodel
-streamlit==1.35.0
+streamlit==1.46.1
 stripe
 uvicorn
 web3


### PR DESCRIPTION
* Adds sidebar toggle for 5-second auto-refresh
* Adds “Replay negotiation” modal that steps through each turn
* Plots last-N quote prices with Matplotlib line-chart
* Refactors fetch() to accept dynamic row limit
* Updates README with dashboard screenshot placeholder

![Screenshot 2025-07-01 at 7 01 28 PM](https://github.com/user-attachments/assets/eccc5384-b634-41a4-8837-d479241bef80)

![Screenshot 2025-07-01 at 7 01 46 PM](https://github.com/user-attachments/assets/3be093fc-f1d2-472d-9d11-87e75b2cb189)

![Screenshot 2025-07-01 at 7 01 59 PM](https://github.com/user-attachments/assets/4d618059-fb7e-479b-aac2-162f05c4ea24)