### PR TITLE
feat(observability): OpenTelemetry tracing with Jaeger exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,27 @@ The Streamlit dashboard provides real-time monitoring of agent negotiations:
 - **Quote History**: Adjust the number of visible quotes using the rows slider
 - **Negotiation Replay**: Click any quote row and use "Replay negotiation" to watch the turn-by-turn negotiation process
 - **Price Trends**: View historical price trends for all quotes
+
+## Tracing
+
+The application uses OpenTelemetry with Jaeger for distributed tracing. To use tracing:
+
+1. Start the Jaeger container:
+
+```bash
+docker compose -f docker-compose.tracing.yml up -d
+```
+
+2. Run the application normally. All FastAPI endpoints will be automatically traced.
+
+3. View traces in the Jaeger UI:
+
+- Open http://localhost:16686
+- Select "agentcloud" from the Service dropdown
+- Click "Find Traces" to view request traces
+
+The traces will show:
+
+- HTTP request paths and methods
+- Request/response timing
+- Dependencies and relationships between services

--- a/core/tracing.py
+++ b/core/tracing.py
@@ -1,0 +1,16 @@
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def init_tracer(app_name: str = "agentcloud"):
+    """Initialize OpenTelemetry tracer with OTLP exporter"""
+    provider = TracerProvider(resource=Resource.create({"service.name": app_name}))
+
+    # OTLP exporter - defaults to localhost:4317 for gRPC
+    otlp_exporter = OTLPSpanExporter()
+    provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+
+    trace.set_tracer_provider(provider)

--- a/docker-compose.tracing.yml
+++ b/docker-compose.tracing.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.55
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - '16686:16686' # Web UI
+      - '4317:4317' # OTLP gRPC
+      - '4318:4318' # OTLP HTTP

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,9 @@ mako
 
 paypal-checkout-serversdk==1.0.3
 requests>=2.32  # PayPal auth helper
+
+# OpenTelemetry dependencies
+deprecated>=1.2.14
+opentelemetry-sdk>=1.25.0
+opentelemetry-instrumentation-fastapi>=0.44b0
+opentelemetry-exporter-otlp>=1.25.0


### PR DESCRIPTION
- `core/tracing.py`
  * sets up TracerProvider + BatchSpanProcessor
  * exports to local Jaeger agent (`localhost:6831`)
- `main.py`
  * calls `init_tracer()` and auto-instruments FastAPI
- `requirements.txt`
  * + opentelemetry-sdk, instrumentation-fastapi, exporter-otlp, deprecated
- `docker-compose.tracing.yml`
  * Jaeger service for local demo
- `README.md`
  * new “Tracing” section with quick-start commands

![Screenshot 2025-07-01 at 8 01 17 PM](https://github.com/user-attachments/assets/82741250-bf9e-4df6-94a2-35f573b257a5)
